### PR TITLE
Docs updated (`useServiceAccountAuth` -> `useServiceAccount`)

### DIFF
--- a/docs/classdocs/sheetdatabase.md
+++ b/docs/classdocs/sheetdatabase.md
@@ -40,7 +40,7 @@ Param|Type|Required|Description
 
 > See [Getting Started > Authentication > API Key](getting-started/authentication#api-key) for more details
 
-#### `useServiceAccountAuth(creds)` (async) :id=method-useServiceAccountAuth
+#### `useServiceAccount(creds)` (async) :id=method-useServiceAccount
 > Initialize JWT-style auth for [google service account](https://cloud.google.com/iam/docs/service-accounts)
 
 Param|Type|Required|Description

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -77,10 +77,10 @@ You can now use this file in your project to authenticate as your service accoun
 ```javascript
 const creds = require('./config/app-credentials.json'); // the file saved above
 const db = new SheetDatabase('<YOUR-SHEETS-DOC-ID>');
-await db.useServiceAccountAuth(creds);
+await db.useServiceAccount(creds);
 
 // or preferably, loading that info from env vars / config instead of the file
-await db.useServiceAccountAuth({
+await db.useServiceAccount({
   client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
   private_key: process.env.GOOGLE_PRIVATE_KEY,
 });


### PR DESCRIPTION
Hey there

I found it a bit misleading, as the `useServiceAccountAuth` specified under docs pages does not exist in the codebase.

Thanks for this helpful module! 